### PR TITLE
add a flag to FormatAddress() to tell it to add double quotes around …

### DIFF
--- a/gomail.go
+++ b/gomail.go
@@ -132,11 +132,11 @@ func (msg *Message) SetHeaders(h map[string][]string) {
 
 // SetAddressHeader sets an address to the given header field.
 func (msg *Message) SetAddressHeader(field, address, name string) {
-	msg.header[field] = []string{msg.FormatAddress(address, name)}
+	msg.header[field] = []string{msg.FormatAddress(address, name, false)}
 }
 
 // FormatAddress formats an address and a name as a valid RFC 5322 address.
-func (msg *Message) FormatAddress(address, name string) string {
+func (msg *Message) FormatAddress(address, name string, useQuotes bool) string {
 	if name == "" {
 		return address
 	}
@@ -152,7 +152,13 @@ func (msg *Message) FormatAddress(address, name string) string {
 		} else {
 			n = encodeHeader(msg.hEncoder, name)
 		}
+		if useQuotes {
+			buf.WriteByte('"')
+		}
 		buf.WriteString(n)
+		if useQuotes {
+			buf.WriteByte('"')
+		}
 	}
 	buf.WriteString(" <")
 	buf.WriteString(address)


### PR DESCRIPTION
Context: 
https://jira.sendgrid.net/browse/CORE-3040

PRD:
https://docs.google.com/document/d/15KVSSG72CGX4MskVJZfUe11HuKnSh05vdiJMTZf5UIc/edit#
"If the Name portion contains unicode, it must be enclosed in double quotes (it is okay to validate against this and add them if needed)"
