### PR TITLE
Make newline a var to prevent reallocating #patch

### DIFF
--- a/export.go
+++ b/export.go
@@ -242,6 +242,8 @@ func newQpLineWriter(w io.Writer) *qpLineWriter {
 	return &qpLineWriter{w: w}
 }
 
+var newline []byte = []byte("=\r\n")
+
 func (w *qpLineWriter) Write(p []byte) (int, error) {
 	n := 0
 	for len(p) > 0 {
@@ -275,7 +277,7 @@ func (w *qpLineWriter) Write(p []byte) (int, error) {
 
 		// Insert the newline where it is needed
 		w.w.Write(p[:toWrite])
-		w.w.Write([]byte("=\r\n"))
+		w.w.Write(newline)
 		p = p[toWrite:]
 		n += toWrite
 		w.lineLen = 0


### PR DESCRIPTION
Initialize newline slice once, rather than repeatedly. 

<img width="872" alt="Screen Shot 2022-09-27 at 9 27 05 AM" src="https://user-images.githubusercontent.com/3535258/192568959-1a944854-3f94-4216-907b-fae12488eaf3.png">
